### PR TITLE
Optional '=' character in create table options

### DIFF
--- a/lib/scheman/parsers/mysql.rb
+++ b/lib/scheman/parsers/mysql.rb
@@ -195,17 +195,17 @@ module Scheman
         end
 
         rule(:comment_table_option) do
-          case_insensitive_str("comment") >> spaces? >> str("=") >> spaces? >> single_quoted(match("[^']").repeat(1))
+          case_insensitive_str("comment") >> (spaces? >> str("=") >> spaces? | spaces) >> single_quoted(match("[^']").repeat(1))
         end
 
         rule(:charset_table_option) do
           case_insensitive_str("default ").maybe >>
             (case_insensitive_str("charset") | case_insensitive_str("character set")) >>
-            spaces? >> str("=") >> spaces? >> word
+            (spaces? >> str("=") >> spaces? | spaces) >> word
         end
 
         rule(:other_table_option) do
-          word >> spaces? >> str("=") >> spaces? >> (word | single_quoted(word) | double_quoted(word))
+          word >> (spaces? >> str("=") >> spaces? | spaces) >> (word | single_quoted(word) | double_quoted(word))
         end
 
         rule(:table_components) do

--- a/spec/scheman/parsers/mysql_spec.rb
+++ b/spec/scheman/parsers/mysql_spec.rb
@@ -554,5 +554,15 @@ describe Scheman::Parsers::Mysql do
         expect { subject }.not_to raise_error
       end
     end
+
+    context "'=' character is optional in create table options" do
+      let(:str) do
+        "CREATE TABLE `table1` (`column1` INTEGER) COMMENT 'hoge' ENGINE MyISAM DEFAULT CHARACTER SET latin1;"
+      end
+
+      it "succeeds in parse" do
+        expect { subject }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
According to [13.1.17 Create Table Syntax](http://dev.mysql.com/doc/refman/5.6/en/create-table.html),
`=` character presented in `table_option` is **optional**.
Thus, 
```
CREATE TABLE `table1` (`column1` INTEGER) COMMENT 'hoge' ENGINE MyISAM DEFAULT CHARACTER SET latin1;
```
is valid statement.