### PR TITLE
Optionally quoted identifier for column and index name

### DIFF
--- a/lib/scheman/parsers/mysql.rb
+++ b/lib/scheman/parsers/mysql.rb
@@ -442,9 +442,7 @@ module Scheman
 
         rule(:quoted_identifier) do
           (
-            single_quoted(match("[^']").repeat(1)) |
-              double_quoted(match('[^"]').repeat(1)) |
-              back_quoted(match("[^`]").repeat(1))
+            back_quoted(match("[^`]").repeat(1))
           ).as(:quoted_identifier)
         end
 

--- a/lib/scheman/parsers/mysql.rb
+++ b/lib/scheman/parsers/mysql.rb
@@ -273,7 +273,7 @@ module Scheman
         end
 
         rule(:index_name) do
-          identifier.as(:index_name)
+          (quoted_identifier | identifier).as(:index_name)
         end
 
         # TODO: Fix spaces not to allow no space
@@ -403,7 +403,7 @@ module Scheman
         end
 
         rule(:column_name) do
-          quoted_identifier.as(:column_name)
+          (quoted_identifier | identifier).as(:column_name)
         end
 
         rule(:value) do

--- a/spec/scheman/parsers/mysql_spec.rb
+++ b/spec/scheman/parsers/mysql_spec.rb
@@ -417,7 +417,7 @@ describe Scheman::Parsers::Mysql do
 
     context "with KEY" do
       let(:str) do
-        "CREATE TABLE `table1` (`column1` INTEGER, KEY index1 (`column1`));"
+        "CREATE TABLE `table1` (`column1` INTEGER, KEY `index1` (`column1`));"
       end
 
       it "succeeds in parse" do


### PR DESCRIPTION
```CREATE TABLE `table1` (`column1` INTEGER, KEY `index1` (column1));```
is a valid MySQL create statement that is currently refused by Scheman.