### PR TITLE
Comment out as a space

### DIFF
--- a/lib/scheman/parsers/mysql.rb
+++ b/lib/scheman/parsers/mysql.rb
@@ -89,7 +89,7 @@ module Scheman
         end
 
         rule(:space) do
-          match('\s')
+          match('\s') | comment
         end
 
         rule(:space?) do
@@ -222,7 +222,7 @@ module Scheman
         end
 
         rule(:create_definition) do
-          index | field | comment
+          index | field
         end
 
         rule(:index) do
@@ -297,12 +297,11 @@ module Scheman
 
         rule(:field) do
           (
-            comment.repeat >> field_name.as(:field_name) >> spaces >> field_type >>
+            field_name.as(:field_name) >> spaces >> field_type >>
               (spaces >> field_qualifiers).maybe.as(:field_qualifiers) >>
               (spaces >> field_comment).maybe >>
               (spaces >> reference_definition).maybe >>
-              (spaces >> on_update).maybe >>
-              comment.maybe
+              (spaces >> on_update).maybe
           ).as(:field)
         end
 

--- a/spec/scheman/parsers/mysql_spec.rb
+++ b/spec/scheman/parsers/mysql_spec.rb
@@ -564,5 +564,23 @@ describe Scheman::Parsers::Mysql do
         expect { subject }.not_to raise_error
       end
     end
+
+    context "with various comment outs" do
+      let(:str) do
+        <<-EOS.strip_heredoc
+          # comment
+          CREATE TABLE `table1` (
+            `column1` INTEGER(11) NOT NULL AUTO_INCREMENT,
+            -- `column1` VARCHAR(11) NOT NULL AUTO_INCREMENT,
+            `column2` VARCHAR(255)/* comment here! */NOT NULL,
+            PRIMARY KEY (`column1`)
+          ); -- comment out
+        EOS
+      end
+
+      it "succeeds in parse" do
+        expect { subject }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
MySQL parses comment out as a space.
Thus,

```
CREATE TABLE `table1` (
  `column1` INTEGER(11) NOT NULL AUTO_INCREMENT,
  -- `column1` VARCHAR(11) NOT NULL AUTO_INCREMENT,
  `column2` VARCHAR(255)/* comment here!! */NOT NULL,
  PRIMARY KEY (`column1`)
); -- comment out
```

is a valid statement.
